### PR TITLE
Prevent automatic dataset load

### DIFF
--- a/load_dataset.py
+++ b/load_dataset.py
@@ -15,5 +15,6 @@ def load_data(path):
     print(f"Total loaded of {path}: {len(data)} reviews")
     return pd.DataFrame({'text': data, 'label': labels})
 
-train = load_data('aclImdb/train')
-test = load_data('aclImdb/test')
+if __name__ == "__main__":
+    train = load_data('aclImdb/train')
+    test = load_data('aclImdb/test')


### PR DESCRIPTION
## Summary
- guard direct dataset loading with a `__main__` block so importing `load_dataset` does not trigger it

## Testing
- `python -m py_compile load_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_6849fe797bfc832da4d584742f268829